### PR TITLE
Update REST server logic to allow entries without SI cards

### DIFF
--- a/code/oEvent.cpp
+++ b/code/oEvent.cpp
@@ -1519,7 +1519,7 @@ pRunner oEvent::dbLookUpById(__int64 extId) const
 
 pRunner oEvent::dbLookUpByCard(int cardNo) const
 {
-  if (!useRunnerDb())
+  if (!useRunnerDb() || cardNo<=0)
     return 0;
 
   oEvent *toe = const_cast<oEvent *>(this);
@@ -1722,14 +1722,11 @@ pRunner oEvent::addRunner(const wstring &name, int clubId, int classId,
   if (birthYear != 0)
     birthYear = extendYear(birthYear);
 
-  if (cardNo>0) {
-    pRunner db_r = oe->dbLookUpByCard(cardNo);
+  pRunner db_r = oe->dbLookUpByCard(cardNo);
 
-    if (db_r && !db_r->matchName(name))
-      db_r = 0; // "Existing" card, but different runner
-  }
-  else 
-    db_r = 0; // card = 0
+  if (db_r && !db_r->matchName(name))
+    db_r = 0; // "Existing" card, but different runner
+
 
   if (db_r == 0 && getNumberSuffix(name) == 0)
     db_r = oe->dbLookUpByName(name, clubId, classId, birthYear);

--- a/code/oEvent.cpp
+++ b/code/oEvent.cpp
@@ -1722,11 +1722,14 @@ pRunner oEvent::addRunner(const wstring &name, int clubId, int classId,
   if (birthYear != 0)
     birthYear = extendYear(birthYear);
 
-  pRunner db_r = oe->dbLookUpByCard(cardNo);
+  if (cardNo>0) {
+    pRunner db_r = oe->dbLookUpByCard(cardNo);
 
-  if (db_r && !db_r->matchName(name))
-    db_r = 0; // "Existing" card, but different runner
-
+    if (db_r && !db_r->matchName(name))
+      db_r = 0; // "Existing" card, but different runner
+  }
+  else 
+    db_r = 0; // card = 0
 
   if (db_r == 0 && getNumberSuffix(name) == 0)
     db_r = oe->dbLookUpByName(name, clubId, classId, birthYear);

--- a/code/restserver.cpp
+++ b/code/restserver.cpp
@@ -1367,10 +1367,10 @@ void RestServer::newEntry(oEvent &oe, const multimap<string, string> &param, str
     if (param.count("card"))
       cardNo = atoi(param.find("card")->second.c_str());
 
-    if (cardNo <= 0) {
+    if (cardNo < 0) {
       error = L"Ogiltigt bricknummer X#" + itow(cardNo);
     }
-    else {
+    else if (cardNo > 0) {
       vector<pRunner> runners;
       oe.getRunnersByCardNo(cardNo, true, oEvent::CardLookupProperty::CardInUse, runners);
       for (auto r : runners) {


### PR DESCRIPTION
Entry of the day participant can enter themselves without SI card number: MeOS should create new runner with empty SI card field. Then the participant can receive a hire card at the registration desk, the card can be assigned "Assign cars" feature in MeOS.
Changes in the code: prevent error "Invalid card number" to be returned by the server on empty/zero SI card field value, prevent runner lookup in the runners database using card number <= 0. Just in case prevent the error in case card 0 is already in the current event.